### PR TITLE
Generator Warning: Implicit Cast to Float

### DIFF
--- a/tinymt/tinymt32.h
+++ b/tinymt/tinymt32.h
@@ -180,7 +180,7 @@ inline static uint32_t tinymt32_generate_uint32(tinymt32_t * random) {
  */
 inline static float tinymt32_generate_float(tinymt32_t * random) {
     tinymt32_next_state(random);
-    return (tinymt32_temper(random) >> 8) * TINYMT32_MUL;
+    return float(tinymt32_temper(random) >> 8) * TINYMT32_MUL;
 }
 
 /**


### PR DESCRIPTION
Fixes the following `-Wconversion` warning in GCC:
```
tinymt32.h: warning: conversion to ‘float’ from ‘uint32_t {aka unsigned int}’ may alter its value [-Wconversion]
     return (tinymt32_temper(random) >> 8) * TINYMT32_MUL;
        ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```

Authored by @krzikalla.

Fix #6

Ref.: https://github.com/alpaka-group/alpaka/issues/994