### PR TITLE
Fix -Wsign-compare Warnings

### DIFF
--- a/tinymt/tinymt32.h
+++ b/tinymt/tinymt32.h
@@ -81,8 +81,10 @@ inline static void tinymt32_next_state(tinymt32_t * random) {
     random->status[1] = random->status[2];
     random->status[2] = x ^ (y << TINYMT32_SH1);
     random->status[3] = y;
-    random->status[1] ^= -((int32_t)(y & 1)) & random->mat1;
-    random->status[2] ^= -((int32_t)(y & 1)) & random->mat2;
+    int32_t const a = -((int32_t)(y & 1)) & (int32_t)random->mat1;
+    int32_t const b = -((int32_t)(y & 1)) & (int32_t)random->mat2;
+    random->status[1] ^= (uint32_t)a;
+    random->status[2] ^= (uint32_t)b;
 }
 
 /**
@@ -102,7 +104,8 @@ inline static uint32_t tinymt32_temper(tinymt32_t * random) {
         + (random->status[2] >> TINYMT32_SH8);
 #endif
     t0 ^= t1;
-    t0 ^= -((int32_t)(t1 & 1)) & random->tmat;
+    int32_t const a = -((int32_t)(t1 & 1)) & (int32_t)random->tmat;
+    t0 ^= (uint32_t)a;
     return t0;
 }
 
@@ -128,8 +131,9 @@ inline static float tinymt32_temper_conv(tinymt32_t * random) {
         + (random->status[2] >> TINYMT32_SH8);
 #endif
     t0 ^= t1;
-    conv.u = ((t0 ^ (-((int32_t)(t1 & 1)) & random->tmat)) >> 9)
-              | UINT32_C(0x3f800000);
+    int32_t const a = -((int32_t)(t1 & 1)) & (int32_t)random->tmat;
+    uint32_t const b = ((t0 ^ ((uint32_t)a)) >> 9) | UINT32_C(0x3f800000);
+    conv.u = b;
     return conv.f;
 }
 
@@ -155,8 +159,9 @@ inline static float tinymt32_temper_conv_open(tinymt32_t * random) {
         + (random->status[2] >> TINYMT32_SH8);
 #endif
     t0 ^= t1;
-    conv.u = ((t0 ^ (-((int32_t)(t1 & 1)) & random->tmat)) >> 9)
-              | UINT32_C(0x3f800001);
+    int32_t const a = -((int32_t)(t1 & 1)) & (int32_t)random->tmat;
+    uint32_t const b = ((t0 ^ ((uint32_t)a)) >> 9) | UINT32_C(0x3f800001);
+    conv.u = b;
     return conv.f;
 }
 


### PR DESCRIPTION
This fixes GCC `-Wsign-compare` warnings. Backported from the Alpaka code base.

Fix #4

Refs.:
- https://github.com/alpaka-group/alpaka/pull/579
- https://github.com/MersenneTwister-Lab/TinyMT/issues/6#issuecomment-625015181
- https://afterthoughtsoftware.com/posts/C-sign-compare