### PR TITLE
[WIP] CI: Add GCC & Clang Builds

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,46 @@
+name: Ubuntu build
+
+on: [push, pull_request]
+
+jobs:
+  build_clang:
+    name: clang [Ubuntu]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        sudo apt-get -qqq update
+        sudo apt-get install -y build-essential clang
+    - name: build as C
+      run: |
+        cd tinymt
+        make CC="clang -Wall -Wextra -Werror -Wsign-compare -Wconversion -O3"
+
+  build_gcc:
+    name: gcc [Ubuntu]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        sudo apt-get -qqq update
+        sudo apt-get install -y build-essential gcc
+    - name: build as C99
+      run: |
+        cd tinymt
+        make CC="gcc -Wall -Wextra -Werror -Wsign-compare -Wconversion -Wmissing-prototypes -O3 -std=c99"
+
+  build_gxx:
+    name: g++ [Ubuntu]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        sudo apt-get -qqq update
+        sudo apt-get install -y build-essential gcc g++
+    - name: build as C++
+      run: |
+        cd tinymt
+        make CC="g++ -Wall -Wextra -Werror -Wsign-compare -Wconversion -O3"


### PR DESCRIPTION
Add builds on each update and pull request. Compiles with `-Wall -Wextra -Werror -Wsign-compare -Wconversion` so that new warnings are caught early.

Also adds a `g++` build to catch warnings in C++ code bases that use TinyMT.

- [ ] #7 #8 #10 must be merged first for this to pass. **Do not merge yet.**